### PR TITLE
Fix Wire.elements-by-name

### DIFF
--- a/lib/Selenium/WebDriver/Wire.pm6
+++ b/lib/Selenium/WebDriver/Wire.pm6
@@ -440,7 +440,7 @@ method element-by-xpath(Str $xpath) {
 =end markdown
 # POST /session/:sessionId/elements
 method _elements(Str $using, Str $value) {
-  my @elements = self._post(
+  my $elements = self._post(
     "elements",
     {
       'using' => $using,
@@ -449,12 +449,12 @@ method _elements(Str $using, Str $value) {
   );
 
   return unless @elements.defined;
-  my @results = gather {
-      take Selenium::WebDriver::WebElement.new(
-        :id( $_<value><ELEMENT> ),
-        :driver( self )
-      ) for @elements;
-  };
+  my @results = $elements<value>.map({
+    Selenium::WebDriver::WebElement.new(
+      :id( $_<ELEMENT> ),
+      :driver( self )
+    )
+  });
 
   return @results;
 }


### PR DESCRIPTION
Before this little code:

  $driver.url("http://google.de");
  my ($input) = $driver.elements-by-name('q');

failed like:

 Type Array does not support associative indexing.
  in block  at /home/froggs/dev/p6-selenium-webdriver/lib/Selenium/WebDriver/Wire.pm6 line 454
  in method _elements at /home/froggs/dev/p6-selenium-webdriver/lib/Selenium/WebDriver/Wire.pm6 line 453
  in method elements-by-name at /home/froggs/dev/p6-selenium-webdriver/lib/Selenium/WebDriver/Wire.pm6 line 489