### PR TITLE
Get `example/chrome.t` version to work by using binary HTTP requests

### DIFF
--- a/examples/chrome.t
+++ b/examples/chrome.t
@@ -14,7 +14,7 @@ my $driver = Selenium::WebDriver::Chrome.new;
 # Navigate to google.com
 $driver.url( "http://google.com" );
 ok $driver.title ~~ / 'Google' /,                "Google in title";
-ok $driver.url   ~~ / ^ 'http://' .+? 'google'/, "google.com in url";
+ok $driver.url   ~~ / ^ 'https://' .+? 'google'/, "google.com in url";
 
 # Find search box and then type "Perl 6" in it
 my $search-box = $driver.element-by-name( 'q' );

--- a/lib/Selenium/WebDriver/Wire.pm6
+++ b/lib/Selenium/WebDriver/Wire.pm6
@@ -747,8 +747,10 @@ method _execute-command(Str $method, Str $command, Hash $params = {}) {
       :Content-Length($content.chars),
       :Content-Type("application/json;charset=UTF-8"),
       :Connection("close"),
+      :bin(True),
     );
-    $request.add-content($content);
+    $request.content = $content.encode;
+    $request.header.field(Content-Length => $request.content.bytes.Str);
     $response = $ua.request($request);
   }
   elsif ( $method eq 'GET' ) {


### PR DESCRIPTION
Prior to this, the `example/chrome.t` would fail with a message about "no response from server".

The cause seems to be `chromedriver` being picky about line endings and `HTTP::UserAgent` adding its own line ending to the end of any non-binary request.

The fix in this pull request is to use a binary request, which allows us to ensure that we use the line ending that `chromedriver` is happy with.